### PR TITLE
minor cleanup for standard python practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-data.sqlite
+.venv
 data.sqlite

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import database
 import interface
-from accounts import Account, load_accounts
+from accounts import load_accounts
 from utilities import thread_function as tf
 
 connection = database.create_connection("data")

--- a/requirements.bat
+++ b/requirements.bat
@@ -1,4 +1,0 @@
-pip install requests
-pip install beautifulsoup4
-pip install pynput
-pip install PySimpleGUI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+beautifulsoup4==4.11.1
+certifi==2022.5.18.1
+charset-normalizer==2.0.12
+evdev==1.5.0
+idna==3.3
+pynput==1.7.6
+PySimpleGUI==4.60.1
+python-xlib==0.31
+requests==2.27.1
+six==1.16.0
+soupsieve==2.3.2.post1
+urllib3==1.26.9


### PR DESCRIPTION
FIrst, I decided to move everything (behind the scenes) into a virtual environment. You would not see this in commit history, since this is actually something users can opt-in to, however it's often recommended and done especially in situations where there are a lot of requirements.

In order to access the VENV operations, you can run `python -m venv .venv` in the _root_ directory of your project. Usually after this you would re-import your project through your IDE, most can automatically detect a virtual environment. 


Next, I moved the requirements into a more standard *requirements.txt*. This is practiced standard by most python developers and also is a cross-platform friendly solution since then, all you need to do is run `pip install -r requirements.txt`. 

Whether you are in a virtual environment or not will not affect the requirements (though its still recommended to be in a virtual env, since then anything installed by pip is only installed for this project specifically).


Finally, I just removed an unused import. Nothing major, I saw it and decided it could go with no hassle. 

Overall just some quality of life changes. Functionally your code operates in exactly the same way as before.

**Note:** The virtual environment is NOT mandatory. I added support for it through the gitignore change, however it does NOT have to be used. That being said, if you don't use it, you run the risk of bleeding unnecessary dependencies if you ever update your *requirements.txt*, since `pip freeze > requirements.txt` would drag more than just what is necessary for this project. 